### PR TITLE
Fix message width

### DIFF
--- a/plugin/lusty-explorer.vim
+++ b/plugin/lusty-explorer.vim
@@ -847,7 +847,7 @@ class Explorer
       on_refresh()
       highlight_selected_index() if VIM::has_syntax?
       @display.print @current_sorted_matches.map { |x| x.label }
-      @prompt.print
+      @prompt.print Display.max_width
     end
 
     def create_explorer_window
@@ -1469,9 +1469,16 @@ class Prompt
       @input = ""
     end
 
-    def print
+    def print( max_width = 0 )
+      display = @input
+      # we need some extra characters
+      max_width -= 5
+      if ( max_width > 0 && display.length > max_width )
+        display = "..."+display[ (display.length - max_width + 3 ) .. -1] 
+      end
+
       VIM::pretty_msg("Comment", @@PROMPT,
-                      "None", VIM::single_quote_escape(@input),
+                      "None", VIM::single_quote_escape(display),
                       "Underlined", " ")
     end
 

--- a/src/lusty/explorer.rb
+++ b/src/lusty/explorer.rb
@@ -103,7 +103,7 @@ class Explorer
       on_refresh()
       highlight_selected_index() if VIM::has_syntax?
       @display.print @current_sorted_matches.map { |x| x.label }
-      @prompt.print
+      @prompt.print Display.max_width
     end
 
     def create_explorer_window

--- a/src/lusty/prompt.rb
+++ b/src/lusty/prompt.rb
@@ -23,9 +23,16 @@ class Prompt
       @input = ""
     end
 
-    def print
+    def print( max_width = 0 )
+      display = @input
+      # we need some extra characters
+      max_width -= 5
+      if ( max_width > 0 && display.length > max_width )
+        display = "..."+display[ (display.length - max_width + 3 ) .. -1] 
+      end
+
       VIM::pretty_msg("Comment", @@PROMPT,
-                      "None", VIM::single_quote_escape(@input),
+                      "None", VIM::single_quote_escape(display),
                       "Underlined", " ")
     end
 


### PR DESCRIPTION
Hi,

I'm using the LustyFilesystemExplorer for a few days now and I'm quite happy with it. One problem I have is that I usually have a very long path, and if the path gets longer than the window width, vim always asks for a key press after the "message" (=prompt) has been written. This makes working with the explorer almost impossible.

I tried to fix this, by truncating the prompt to the window width, the patch is in this branch I asked you to pull. 

Bye,

Martin
