### PR TITLE
Call to clearmatches

### DIFF
--- a/plugin/lusty-explorer.vim
+++ b/plugin/lusty-explorer.vim
@@ -1819,6 +1819,8 @@ class Display
         VIM::command 'highlight link LustyFileWithSwap WarningMsg'
         VIM::command 'highlight link LustyNoEntries ErrorMsg'
         VIM::command 'highlight link LustyTruncated Visual'
+
+        VIM::evaluate 'clearmatches()'
       end
 
       #


### PR DESCRIPTION
I have added a match to my vimrc to display trailing whitespace characters in
red (see appendix).  This has the side-effect that in the Lusty-Explorer buffer
some trailing whitespace/tab characters are also highlighted in red.
My current solution is to add the following line to lusty-explorer.vim:

```
    VIM::evaluate 'clearmatches()'
```

Appendix:
        highlight ExtraWhitespace ctermbg=red guibg=red
        autocmd ColorScheme \* highlight ExtraWhitespace ctermbg=red guibg=red
        match ExtraWhitespace /\s+$/
        autocmd BufWinEnter \* match ExtraWhitespace /\s+$/
        autocmd InsertEnter \* match ExtraWhitespace /\s+\%#\@<!$/
        autocmd InsertLeave \* match ExtraWhitespace /\s+$/
        autocmd BufWinLeave \* call clearmatches()
