### PR TITLE
Better restoring of mappings

### DIFF
--- a/plugin/lusty-explorer.vim
+++ b/plugin/lusty-explorer.vim
@@ -368,6 +368,11 @@ module VIM
     nonzero? evaluate('has("syntax")')
   end
 
+  def self.has_ext_maparg?
+    # The 'dict' parameter to mapargs() was introduced in Vim 7.3.32
+    nonzero? evaluate('v:version > 703 || (v:version == 703 && has("patch32"))')
+  end
+
   def self.columns
     evaluate("&columns").to_i
   end

--- a/src/juggler.vim
+++ b/src/juggler.vim
@@ -116,7 +116,6 @@
 " GetLatestVimScripts: 2050 1 :AutoInstall: lusty-juggler.vim
 "
 " TODO:
-" - save and restore mappings
 " - Add TAB recognition back.
 " - Add option to open buffer immediately when mapping is pressed (but not
 "   release the juggler until the confirmation press).
@@ -240,7 +239,11 @@ augroup LustyJuggler
 augroup End
 
 " Used to work around a flaw in Vim's ruby bindings.
-let s:maparg_holder = 0
+if v:version > 703 || (v:version == 703 && has("patch32"))
+  let s:maparg_holder = { }
+else
+  let s:maparg_holder = 0
+endif
 
 ruby << EOF
 

--- a/src/vim.rb
+++ b/src/vim.rb
@@ -42,6 +42,11 @@ module VIM
     nonzero? evaluate('has("syntax")')
   end
 
+  def self.has_ext_maparg?
+    # The 'dict' parameter to mapargs() was introduced in Vim 7.3.32
+    nonzero? evaluate('v:version > 703 || (v:version == 703 && has("patch32"))')
+  end
+
   def self.columns
     evaluate("&columns").to_i
   end


### PR DESCRIPTION
As mentioned to Stephen, here's a fix to use the extended form of mapargs() introduced in Vim 7.3.32, if available, to ensure more faithful restoration of key mappings after the juggler is closed.
