### PR TITLE
Ability to open buffers in splits from LustyJuggler

### DIFF
--- a/plugin/lusty-juggler.vim
+++ b/plugin/lusty-juggler.vim
@@ -568,7 +568,6 @@ class LustyJuggler
       # Split opener keys
       map_key("v", ":call <SID>LustyJugglerKeyPressed('v')<CR>")
       map_key("b", ":call <SID>LustyJugglerKeyPressed('b')<CR>")
-      map_key("<Tab>", ":call <SID>LustyJugglerKeyPressed('TAB')<CR>")
 
       # Cancel keys.
       map_key("i", ":call <SID>LustyJugglerCancel()<CR>")

--- a/src/lusty/juggler.rb
+++ b/src/lusty/juggler.rb
@@ -77,7 +77,6 @@ class LustyJuggler
       # Split opener keys
       map_key("v", ":call <SID>LustyJugglerKeyPressed('v')<CR>")
       map_key("b", ":call <SID>LustyJugglerKeyPressed('b')<CR>")
-      map_key("<Tab>", ":call <SID>LustyJugglerKeyPressed('TAB')<CR>")
 
       # Cancel keys.
       map_key("i", ":call <SID>LustyJugglerCancel()<CR>")


### PR DESCRIPTION
Hi,

I was missing the ability to quickly open a buffer in a split. So I've added two more keybindings
- `<buffer_number> b` - opens buffer in horizontal split
- `<buffer_number> v` - opens buffer in vertical split

For example, `<leader>lj2v` opens the second buffer in a vertical split.

I chose `b` over `h` because `h` is already bound to buffer no 6.
