### PR TITLE
fix "incompatible character encodings" error with Ruby 1.9

### DIFF
--- a/plugin/lusty-explorer.vim
+++ b/plugin/lusty-explorer.vim
@@ -1083,6 +1083,7 @@ class FilesystemExplorer < Explorer
       if path.empty?
         path = VIM::getcwd()
       end
+      path = path.force_encoding VIM::evaluate('&enc')
       @prompt.set!(path + File::SEPARATOR)
       run()
     end

--- a/src/lusty/filesystem-explorer.rb
+++ b/src/lusty/filesystem-explorer.rb
@@ -30,6 +30,7 @@ class FilesystemExplorer < Explorer
       if path.empty?
         path = VIM::getcwd()
       end
+      path = path.force_encoding VIM::evaluate('&enc')
       @prompt.set!(path + File::SEPARATOR)
       run()
     end


### PR DESCRIPTION
This error occurs when the path contains non-ASCII, which will be in
ASCII-8BIT encoding in Ruby 1.9, while the `Dir` entries are in UTF-8.

However, I don't know what impact it will be on Ruby 1.8. Maybe it should be handled differently?
