### PR TITLE
 <Left> and <Right> support in lusty-juggler and \| mapping restore fix

### DIFF
--- a/plugin/lusty-juggler.vim
+++ b/plugin/lusty-juggler.vim
@@ -598,10 +598,12 @@ class LustyJuggler
         c=='v' ? vsplit(@last_pressed) : hsplit(@last_pressed)
         cleanup()
       elsif c == 'Left'
-        @last_pressed = (@last_pressed - 1) < 1? 1 : (@last_pressed - 1)
+        @last_pressed = (@last_pressed.nil?) ? 0 : (@last_pressed)
+        @last_pressed = (@last_pressed - 1) < 1 ? $lj_buffer_stack.length : (@last_pressed - 1)
         print_buffer_list(@last_pressed)
       elsif c == 'Right'
-        @last_pressed = (@last_pressed + 1) > 10? 10 : (@last_pressed + 1)
+        @last_pressed = (@last_pressed.nil?) ? 0 : (@last_pressed)
+        @last_pressed = (@last_pressed + 1) > $lj_buffer_stack.length ? 1 : (@last_pressed + 1)
         print_buffer_list(@last_pressed)
       else
         @last_pressed = @@KEYS[c]

--- a/src/lusty/juggler.rb
+++ b/src/lusty/juggler.rb
@@ -107,10 +107,12 @@ class LustyJuggler
         c=='v' ? vsplit(@last_pressed) : hsplit(@last_pressed)
         cleanup()
       elsif c == 'Left'
-        @last_pressed = (@last_pressed - 1) < 1? 1 : (@last_pressed - 1)
+        @last_pressed = (@last_pressed.nil?) ? 0 : (@last_pressed)
+        @last_pressed = (@last_pressed - 1) < 1 ? $lj_buffer_stack.length : (@last_pressed - 1)
         print_buffer_list(@last_pressed)
       elsif c == 'Right'
-        @last_pressed = (@last_pressed + 1) > 10? 10 : (@last_pressed + 1)
+        @last_pressed = (@last_pressed.nil?) ? 0 : (@last_pressed)
+        @last_pressed = (@last_pressed + 1) > $lj_buffer_stack.length ? 1 : (@last_pressed + 1)
         print_buffer_list(@last_pressed)
       else
         @last_pressed = @@KEYS[c]


### PR DESCRIPTION
First off, thanks @sjbach for merging :)
As per the topics, this adds <Left> and <Right> support in lusty-juggler and fixes the mapping restore commands for mapping that have | on the rhs, for example I have `nnoremap <C-h>  <C-w>h<C-w>\|<C-w>_`
cheers,
Giuseppe
