### PR TITLE
Fixed minor file explorer bug.

### DIFF
--- a/plugin/lusty-explorer.vim
+++ b/plugin/lusty-explorer.vim
@@ -823,14 +823,23 @@ class Explorer
           @prompt.up_one_dir!
           @selected_index = 0
         when 14               # C-n (select next)
-          @selected_index = \
+          @selected_index = if @current_sorted_matches.size.zero?
+                              0
+                            else
             (@selected_index + 1) % @current_sorted_matches.size
+                            end
           refresh_mode = :no_recompute
         when 16               # C-p (select previous)
-          @selected_index = \
+          @selected_index = if @current_sorted_matches.size.zero?
+                              0
+                            else
             (@selected_index - 1) % @current_sorted_matches.size
+                            end
           refresh_mode = :no_recompute
         when 6                # C-f (select right)
+          @selected_index = if @row_count.nil? || @row_count.zero?
+                              0
+                            else
           columns = (@current_sorted_matches.size.to_f / @row_count.to_f).ceil
           cur_column = @selected_index / @row_count
           cur_row = @selected_index % @row_count
@@ -838,9 +847,13 @@ class Explorer
           if (new_column + 1) * (cur_row + 1) > @current_sorted_matches.size
             new_column = 0
           end
-          @selected_index = new_column * @row_count + cur_row
+                              new_column * @row_count + cur_row
+                            end
           refresh_mode = :no_recompute
         when 2                # C-b (select left)
+          @selected_index = if @row_count.nil? || @row_count.zero?
+                              0
+                            else
           columns = (@current_sorted_matches.size.to_f / @row_count.to_f).ceil
           cur_column = @selected_index / @row_count
           cur_row = @selected_index % @row_count
@@ -848,7 +861,8 @@ class Explorer
           if (new_column + 1) * (cur_row + 1) > @current_sorted_matches.size
             new_column = columns - 2
           end
-          @selected_index = new_column * @row_count + cur_row
+                              new_column * @row_count + cur_row
+                            end
           refresh_mode = :no_recompute
         when 15               # C-o choose in new horizontal split
           choose(:new_split)

--- a/src/lusty/explorer.rb
+++ b/src/lusty/explorer.rb
@@ -53,14 +53,23 @@ class Explorer
           @prompt.up_one_dir!
           @selected_index = 0
         when 14               # C-n (select next)
-          @selected_index = \
+          @selected_index = if @current_sorted_matches.size.zero?
+                              0
+                            else
             (@selected_index + 1) % @current_sorted_matches.size
+                            end
           refresh_mode = :no_recompute
         when 16               # C-p (select previous)
-          @selected_index = \
+          @selected_index = if @current_sorted_matches.size.zero?
+                              0
+                            else
             (@selected_index - 1) % @current_sorted_matches.size
+                            end
           refresh_mode = :no_recompute
         when 6                # C-f (select right)
+          @selected_index = if @row_count.nil? || @row_count.zero?
+                              0
+                            else
           columns = (@current_sorted_matches.size.to_f / @row_count.to_f).ceil
           cur_column = @selected_index / @row_count
           cur_row = @selected_index % @row_count
@@ -68,9 +77,13 @@ class Explorer
           if (new_column + 1) * (cur_row + 1) > @current_sorted_matches.size
             new_column = 0
           end
-          @selected_index = new_column * @row_count + cur_row
+                              new_column * @row_count + cur_row
+                            end
           refresh_mode = :no_recompute
         when 2                # C-b (select left)
+          @selected_index = if @row_count.nil? || @row_count.zero?
+                              0
+                            else
           columns = (@current_sorted_matches.size.to_f / @row_count.to_f).ceil
           cur_column = @selected_index / @row_count
           cur_row = @selected_index % @row_count
@@ -78,7 +91,8 @@ class Explorer
           if (new_column + 1) * (cur_row + 1) > @current_sorted_matches.size
             new_column = columns - 2
           end
-          @selected_index = new_column * @row_count + cur_row
+                              new_column * @row_count + cur_row
+                            end
           refresh_mode = :no_recompute
         when 15               # C-o choose in new horizontal split
           choose(:new_split)


### PR DESCRIPTION
To replicate bug:
1. Open two vim buffers.
2. Type <Leader>lf or <Leader>lg
3. Type in a bunch of garbage that will not match any files, such as "sanhunehuanhurruhensuohsh"
4. Press any arrow key (up, left, right, down)
5. Ruby NaN or Divide by Zero error is displayed.

Fix: Now pressing any direction key does nothing in this scenario, but works normally otherwise.
