### PR TITLE
Close buffer from buffer explorer

### DIFF
--- a/plugin/lusty-explorer.vim
+++ b/plugin/lusty-explorer.vim
@@ -905,6 +905,8 @@ class Explorer
           @selected_index = 0
         when 22               # C-v choose in new vertical split
           choose(:new_vsplit)
+        when 24               # C-d remove buffer
+          remove_buffer()
       end
 
       refresh(refresh_mode)
@@ -961,6 +963,19 @@ class Explorer
       label_match_string = Display.entry_syntaxify(escaped, false)
       VIM::command "syn match LustySelected \"#{label_match_string}\" " \
                                             'contains=LustyGrepMatch'
+    end
+
+    def remove_buffer()
+      entry = @current_sorted_matches[@selected_index]
+      return if entry.nil?
+
+      cleanup()
+      LustyE::assert($curwin == @calling_window)
+
+      number = entry.vim_buffer.number
+      LustyE::assert(number)
+
+      VIM::command "bdelete #{number}"
     end
 
     def choose(open_mode)
@@ -1930,6 +1945,7 @@ class Display
       VIM::command "#{map} <C-e>    :call <SID>#{prefix}KeyPressed(5)<CR>"
       VIM::command "#{map} <C-r>    :call <SID>#{prefix}KeyPressed(18)<CR>"
       VIM::command "#{map} <C-u>    :call <SID>#{prefix}KeyPressed(21)<CR>"
+      VIM::command "#{map} <C-d>    :call <SID>#{prefix}KeyPressed(24)<CR>"
       VIM::command "#{map} <Esc>OD  :call <SID>#{prefix}KeyPressed(2)<CR>"
       VIM::command "#{map} <Esc>OC  :call <SID>#{prefix}KeyPressed(6)<CR>"
       VIM::command "#{map} <Esc>OA  :call <SID>#{prefix}KeyPressed(16)<CR>"

--- a/plugin/lusty-explorer.vim
+++ b/plugin/lusty-explorer.vim
@@ -966,16 +966,18 @@ class Explorer
     end
 
     def remove_buffer()
-      entry = @current_sorted_matches[@selected_index]
-      return if entry.nil?
+      if self.class.to_s.sub(/.*::/,'') == "BufferExplorer"
+        entry = @current_sorted_matches[@selected_index]
+        return if entry.nil?
 
-      cleanup()
-      LustyE::assert($curwin == @calling_window)
+        cleanup()
+        LustyE::assert($curwin == @calling_window)
 
-      number = entry.vim_buffer.number
-      LustyE::assert(number)
+        number = entry.vim_buffer.number
+        LustyE::assert(number)
 
-      VIM::command "bdelete #{number}"
+        VIM::command "bdelete #{number}"
+      end
     end
 
     def choose(open_mode)


### PR DESCRIPTION
I added the mapping of C-d to delete a buffer from within the buffer explorer. I'm not sure how stable or secure this is, as I'm not the vim-script or ruby guy... But it works without any errors so far...
