### PR TITLE
Fix typo in src/juggler.vim and build plugin

### DIFF
--- a/plugin/lusty-juggler.vim
+++ b/plugin/lusty-juggler.vim
@@ -1233,7 +1233,7 @@ end
 
 if VIM::exists?('g:LustyJugglerKeyboardLayout') and VIM::evaluate_bool('g:LustyJugglerKeyboardLayout == "dvorak"')
   $lusty_juggler = LustyJ::LustyJugglerDvorak.new
-elseif VIM::exists?('g:LustyJugglerKeyboardLayout') and VIM::evaluate_bool('g:LustyJugglerKeyboardLayout == "colemak"')
+elsif VIM::exists?('g:LustyJugglerKeyboardLayout') and VIM::evaluate_bool('g:LustyJugglerKeyboardLayout == "colemak"')
   $lusty_juggler = LustyJ::LustyJugglerColemak.new
 else 
   $lusty_juggler = LustyJ::LustyJuggler.new

--- a/src/juggler.vim
+++ b/src/juggler.vim
@@ -292,7 +292,7 @@ end
 
 if VIM::exists?('g:LustyJugglerKeyboardLayout') and VIM::evaluate_bool('g:LustyJugglerKeyboardLayout == "dvorak"')
   $lusty_juggler = LustyJ::LustyJugglerDvorak.new
-elseif VIM::exists?('g:LustyJugglerKeyboardLayout') and VIM::evaluate_bool('g:LustyJugglerKeyboardLayout == "colemak"')
+elsif VIM::exists?('g:LustyJugglerKeyboardLayout') and VIM::evaluate_bool('g:LustyJugglerKeyboardLayout == "colemak"')
   $lusty_juggler = LustyJ::LustyJugglerColemak.new
 else 
   $lusty_juggler = LustyJ::LustyJuggler.new


### PR DESCRIPTION
There was an error in my ruby code.
Also I ran `make` to rebuild the plugin
