### PR TITLE
Fix buffer stack for when you source a vim session file

### DIFF
--- a/plugin/lusty-explorer.vim
+++ b/plugin/lusty-explorer.vim
@@ -322,7 +322,7 @@ endfunction
 " Setup the autocommands that handle buffer MRU ordering.
 augroup LustyExplorer
   autocmd!
-  autocmd BufEnter * ruby LustyE::profile() { $le_buffer_stack.push }
+  autocmd BufAdd,BufEnter * ruby LustyE::profile() { $le_buffer_stack.push }
   autocmd BufDelete * ruby LustyE::profile() { $le_buffer_stack.pop }
   autocmd BufWipeout * ruby LustyE::profile() { $le_buffer_stack.pop }
 augroup End
@@ -2356,12 +2356,13 @@ class BufferStack
     end
 
     def push
-      @stack.delete $curbuf.number
-      @stack << $curbuf.number
+      buf_number = VIM::evaluate('expand("<abuf>")').to_i
+      @stack.delete buf_number
+      @stack << buf_number
     end
 
     def pop
-      number = VIM::evaluate('bufnr(expand("<afile>"))')
+      number = VIM::evaluate('bufnr(expand("<abuf>"))')
       @stack.delete number
     end
 

--- a/plugin/lusty-juggler.vim
+++ b/plugin/lusty-juggler.vim
@@ -258,7 +258,7 @@ endfunction
 " Setup the autocommands that handle buffer MRU ordering.
 augroup LustyJuggler
   autocmd!
-  autocmd BufEnter * ruby LustyJ::profile() { $lj_buffer_stack.push }
+  autocmd BufAdd,BufEnter * ruby LustyJ::profile() { $lj_buffer_stack.push }
   autocmd BufDelete * ruby LustyJ::profile() { $lj_buffer_stack.pop }
   autocmd BufWipeout * ruby LustyJ::profile() { $lj_buffer_stack.pop }
 augroup End
@@ -1142,12 +1142,13 @@ class BufferStack
     end
 
     def push
-      @stack.delete $curbuf.number
-      @stack << $curbuf.number
+      buf_number = VIM::evaluate('expand("<abuf>")').to_i
+      @stack.delete buf_number
+      @stack << buf_number
     end
 
     def pop
-      number = VIM::evaluate('bufnr(expand("<afile>"))')
+      number = VIM::evaluate('bufnr(expand("<abuf>"))')
       @stack.delete number
     end
 

--- a/src/explorer.vim
+++ b/src/explorer.vim
@@ -322,7 +322,7 @@ endfunction
 " Setup the autocommands that handle buffer MRU ordering.
 augroup LustyExplorer
   autocmd!
-  autocmd BufEnter * ruby LustyE::profile() { $le_buffer_stack.push }
+  autocmd BufAdd,BufEnter * ruby LustyE::profile() { $le_buffer_stack.push }
   autocmd BufDelete * ruby LustyE::profile() { $le_buffer_stack.pop }
   autocmd BufWipeout * ruby LustyE::profile() { $le_buffer_stack.pop }
 augroup End

--- a/src/juggler.vim
+++ b/src/juggler.vim
@@ -258,7 +258,7 @@ endfunction
 " Setup the autocommands that handle buffer MRU ordering.
 augroup LustyJuggler
   autocmd!
-  autocmd BufEnter * ruby LustyJ::profile() { $lj_buffer_stack.push }
+  autocmd BufAdd,BufEnter * ruby LustyJ::profile() { $lj_buffer_stack.push }
   autocmd BufDelete * ruby LustyJ::profile() { $lj_buffer_stack.pop }
   autocmd BufWipeout * ruby LustyJ::profile() { $lj_buffer_stack.pop }
 augroup End

--- a/src/lusty/buffer-stack.rb
+++ b/src/lusty/buffer-stack.rb
@@ -62,12 +62,13 @@ class BufferStack
     end
 
     def push
-      @stack.delete $curbuf.number
-      @stack << $curbuf.number
+      buf_number = VIM::evaluate('expand("<abuf>")').to_i
+      @stack.delete buf_number
+      @stack << buf_number
     end
 
     def pop
-      number = VIM::evaluate('bufnr(expand("<afile>"))')
+      number = VIM::evaluate('bufnr(expand("<abuf>"))')
       @stack.delete number
     end
 


### PR DESCRIPTION
This patch solves the issue I'm having while sourcing a vim session file that i saved with `:mksession` before.
The problem is the following:
1. load a bunch of files in vim
2. save a session file with `:mksession`
3. quit vim
4. come back later, re-launch vim, source the previous session file.
5. Call `:LustyBufferExplorer` or `:LustyJuggler`. You won't see all the listed files but only the one currently show.
