### PR TITLE
Don't resize $curwin when setting max window height

### DIFF
--- a/plugin/lusty-explorer.vim
+++ b/plugin/lusty-explorer.vim
@@ -2071,9 +2071,9 @@ class Display
       unlock_and_clear()
 
       # Grow/shrink the window as needed
-      old_height = $curwin.height
+#      old_height = $curwin.height
       $curwin.height = rows.length + (truncated ? 1 : 0)
-      VIM::command("exe g:winstate") if $curwin.height < old_height
+#      VIM::command("exe g:winstate") if $curwin.height < old_height
 
       # Print the rows.
       rows.each_index do |i|

--- a/src/lusty/display.rb
+++ b/src/lusty/display.rb
@@ -290,9 +290,9 @@ class Display
       unlock_and_clear()
 
       # Grow/shrink the window as needed
-      old_height = $curwin.height
+#      old_height = $curwin.height
       $curwin.height = rows.length + (truncated ? 1 : 0)
-      VIM::command("exe g:winstate") if $curwin.height < old_height
+#      VIM::command("exe g:winstate") if $curwin.height < old_height
 
       # Print the rows.
       rows.each_index do |i|


### PR DESCRIPTION
This should fix the problem reported in Issue #52, where the bottom-most of 2 or more horizontal splits is resized to fit the whole screen minus 1 line for each of the splits above it. It seems like the issue was simple that the calculation of the max window height was setting the current window size to the max size. I dropped all of the variable shuffling in `Display.max_height` and simple set it to `VIM::MOST_POSITIVE_INTEGER` outright. I don't think this should be a problem, unless you were doing `Display.max_height` to do something other than I expect.

Sorry it took me so long to do this, I didn't have a chance to look at it until a few minutes ago.

Cheers!
