### PR TITLE
<C-d> to delete buffers or files

### DIFF
--- a/src/lusty/buffer-explorer.rb
+++ b/src/lusty/buffer-explorer.rb
@@ -34,6 +34,21 @@ class BufferExplorer < Explorer
       end
     end
 
+    def unload_selected_buffer
+      entry = @current_sorted_matches[@selected_index]
+      return if entry.nil?
+      delete_buffer(entry)
+      refresh(:full)
+      run
+    end
+
+    def delete_buffer(entry)
+      cleanup
+      number = entry.vim_buffer.number
+      LustyE::assert(number)
+      VIM::command "silent bdelete! #{number}"
+    end
+
   private
     def title
       '[LustyExplorer-Buffers]'

--- a/src/lusty/buffer-explorer.rb
+++ b/src/lusty/buffer-explorer.rb
@@ -34,7 +34,7 @@ class BufferExplorer < Explorer
       end
     end
 
-    def unload_selected_buffer
+    def delete
       entry = @current_sorted_matches[@selected_index]
       return if entry.nil?
       delete_buffer(entry)

--- a/src/lusty/display.rb
+++ b/src/lusty/display.rb
@@ -160,6 +160,8 @@ class Display
       VIM::command "#{map} <C-t>    :call <SID>#{prefix}KeyPressed(20)<CR>"
       VIM::command "#{map} <C-v>    :call <SID>#{prefix}KeyPressed(22)<CR>"
       VIM::command "#{map} <C-e>    :call <SID>#{prefix}KeyPressed(5)<CR>"
+      VIM::command "#{map} <C-d>    :call <SID>#{prefix}KeyPressed(4)<CR>"
+      VIM::command "#{map} <C-d>    :call <SID>#{prefix}KeyPressed(4)<CR>"
       VIM::command "#{map} <C-r>    :call <SID>#{prefix}KeyPressed(18)<CR>"
       VIM::command "#{map} <C-u>    :call <SID>#{prefix}KeyPressed(21)<CR>"
       VIM::command "#{map} <Esc>OD  :call <SID>#{prefix}KeyPressed(2)<CR>"

--- a/src/lusty/explorer.rb
+++ b/src/lusty/explorer.rb
@@ -110,7 +110,7 @@ class Explorer
         when 22               # C-v choose in new vertical split
           choose(:new_vsplit)
         when 4
-          unload_selected_buffer()
+          delete()
       end
 
       refresh(refresh_mode)

--- a/src/lusty/explorer.rb
+++ b/src/lusty/explorer.rb
@@ -109,6 +109,8 @@ class Explorer
           @selected_index = 0
         when 22               # C-v choose in new vertical split
           choose(:new_vsplit)
+        when 4
+          unload_selected_buffer()
       end
 
       refresh(refresh_mode)

--- a/src/lusty/filesystem-explorer.rb
+++ b/src/lusty/filesystem-explorer.rb
@@ -67,6 +67,8 @@ class FilesystemExplorer < Explorer
           @memoized_dir_contents.delete(view_path())
           load_file(@prompt.input, :current_tab)
         end
+      when 4      # <C-d> delete buffer
+        delete()
       when 18     # <C-r> refresh
         @memoized_dir_contents.delete(view_path())
         refresh(:full)

--- a/src/lusty/filesystem-explorer.rb
+++ b/src/lusty/filesystem-explorer.rb
@@ -77,6 +77,20 @@ class FilesystemExplorer < Explorer
       end
     end
 
+    def delete
+      entry = @current_sorted_matches[@selected_index]
+      return if entry.nil?
+      delete_file(entry)
+      @memoized_dir_contents.delete(view_path())
+      refresh(:full)
+      run
+    end
+
+    def delete_file(entry)
+      cleanup
+      path = view_path() + entry.label
+      VIM::command "call delete('#{path.to_s}')"
+    end
   private
     def title
       '[LustyExplorer-Files]'


### PR DESCRIPTION
This is a duplicate of pull request another pull request (https://github.com/sjbach/lusty/pull/81).  I saw that request had been open for a long time. I have completed the requests made there and expanded on it a bit.

Now <C-d> can be used to delete a file in the filesystem explorer as well as delete a buffer in the buffer explorer.