### PR TITLE
Lusty Juggler crashing on OS X Vim 73

### DIFF
--- a/plugin/lusty-juggler.vim
+++ b/plugin/lusty-juggler.vim
@@ -717,7 +717,7 @@ class LustyJuggler
       end
 
       @running = false
-      VIM::message ''
+      VIM::message ' '
       VIM::command 'redraw'  # Prevents "Press ENTER to continue" message.
     end
 


### PR DESCRIPTION
Hello mate,

I found using VIM::message '' breaks vim 73 on OS X. I can reproduce this by simply running (in vim) ruby VIM::message ''.

While I know this is a VIM/Ruby problem, I would like to see the juggler work until I find out how to fix the bigger issue.

Thanks for your work so far! 
