### PR TITLE
Lusty Juggler crashing on OS X Vim 73

### DIFF
--- a/src/lusty/juggler.rb
+++ b/src/lusty/juggler.rb
@@ -153,7 +153,7 @@ class LustyJuggler
       end
 
       @running = false
-      VIM::message ''
+      VIM::message ' '
       VIM::command 'redraw'  # Prevents "Press ENTER to continue" message.
     end
 


### PR DESCRIPTION
Workaround for what looks to be a bug in Vim 73 ruby extensions. This keeps the juggler working!

Sorry for the earlier commit, was working a little to late I think! ;)
