### PR TITLE
Prevent entering Insert mode using "I" or "A" while lusty-juggler is open.

### DIFF
--- a/plugin/lusty-juggler.vim
+++ b/plugin/lusty-juggler.vim
@@ -820,6 +820,8 @@ class LustyJugglerDvorak < LustyJuggler
       @BUFFER_KEYS = @ALPHA_BUFFER_KEYS.merge(@NUMERIC_BUFFER_KEYS)
       @KEYPRESS_MAPPINGS = @BUFFER_KEYS.merge(@KEYPRESS_KEYS)
       @CANCEL_MAPPINGS.delete("i")
+      @CANCEL_MAPPINGS.delete("I")
+      @CANCEL_MAPPINGS.delete("A")
       @CANCEL_MAPPINGS.push("c")
     end
 end
@@ -846,6 +848,8 @@ class LustyJugglerColemak < LustyJuggler
       @BUFFER_KEYS = @ALPHA_BUFFER_KEYS.merge(@NUMERIC_BUFFER_KEYS)
       @KEYPRESS_MAPPINGS = @BUFFER_KEYS.merge(@KEYPRESS_KEYS)
       @CANCEL_MAPPINGS.delete("i")
+      @CANCEL_MAPPINGS.delete("I")
+      @CANCEL_MAPPINGS.delete("A")
       @CANCEL_MAPPINGS.push("c")
     end
 end
@@ -872,6 +876,8 @@ class LustyJugglerBepo < LustyJuggler
       @BUFFER_KEYS = @ALPHA_BUFFER_KEYS.merge(@NUMERIC_BUFFER_KEYS)
       @KEYPRESS_MAPPINGS = @BUFFER_KEYS.merge(@KEYPRESS_KEYS)
       @CANCEL_MAPPINGS.delete("i")
+      @CANCEL_MAPPINGS.delete("I")
+      @CANCEL_MAPPINGS.delete("A")
       @CANCEL_MAPPINGS.push("c")
     end
 end

--- a/src/lusty/juggler.rb
+++ b/src/lusty/juggler.rb
@@ -256,6 +256,8 @@ class LustyJugglerDvorak < LustyJuggler
       @BUFFER_KEYS = @ALPHA_BUFFER_KEYS.merge(@NUMERIC_BUFFER_KEYS)
       @KEYPRESS_MAPPINGS = @BUFFER_KEYS.merge(@KEYPRESS_KEYS)
       @CANCEL_MAPPINGS.delete("i")
+      @CANCEL_MAPPINGS.delete("I")
+      @CANCEL_MAPPINGS.delete("A")
       @CANCEL_MAPPINGS.push("c")
     end
 end
@@ -282,6 +284,8 @@ class LustyJugglerColemak < LustyJuggler
       @BUFFER_KEYS = @ALPHA_BUFFER_KEYS.merge(@NUMERIC_BUFFER_KEYS)
       @KEYPRESS_MAPPINGS = @BUFFER_KEYS.merge(@KEYPRESS_KEYS)
       @CANCEL_MAPPINGS.delete("i")
+      @CANCEL_MAPPINGS.delete("I")
+      @CANCEL_MAPPINGS.delete("A")
       @CANCEL_MAPPINGS.push("c")
     end
 end
@@ -308,6 +312,8 @@ class LustyJugglerBepo < LustyJuggler
       @BUFFER_KEYS = @ALPHA_BUFFER_KEYS.merge(@NUMERIC_BUFFER_KEYS)
       @KEYPRESS_MAPPINGS = @BUFFER_KEYS.merge(@KEYPRESS_KEYS)
       @CANCEL_MAPPINGS.delete("i")
+      @CANCEL_MAPPINGS.delete("I")
+      @CANCEL_MAPPINGS.delete("A")
       @CANCEL_MAPPINGS.push("c")
     end
 end


### PR DESCRIPTION
If you press "A" or "I" while the lusty-juggler is active all further key presses are written to the document. I added "A" and "I" to the cancelled mappings to prevent this.
