### PR TITLE
LustyJuggler: Key mappings are not always reset properly

### DIFF
--- a/plugin/lusty-juggler.vim
+++ b/plugin/lusty-juggler.vim
@@ -572,23 +572,11 @@ end
 
 
 module LustyJ
-class LustyJuggler
+class BaseLustyJuggler
   public
     def initialize
       @running = false
       @last_pressed = nil
-      alpha_buffer_keys = [
-        "a",
-        "s",
-        "d",
-        "f",
-        "g",
-        "h",
-        "j",
-        "k",
-        "l",
-        ";",
-      ]
       @name_bar = NameBar.new(alpha_buffer_keys)
       @ALPHA_BUFFER_KEYS = Hash.new
       alpha_buffer_keys.each_with_index {|x, i| @ALPHA_BUFFER_KEYS[x] = i + 1}
@@ -622,24 +610,10 @@ class LustyJuggler
         "<Right>" => "Right",
       }
       @KEYPRESS_MAPPINGS = @BUFFER_KEYS.merge(@KEYPRESS_KEYS)
-      @CANCEL_MAPPINGS = [
-        "i",
-        "I",
-        "A",
-        "c",
-        "C",
-        "o",
-        "O",
-        "S",
-        "r",
-        "R",
-        "q",
-        "<Esc>",
-        "<C-c>",
-        "<BS>",
-        "<Del>",
-        "<C-h>",
-      ]
+    end
+
+    def cancel_mappings
+      @cancel_mappings ||= (default_cancel_mappings - alpha_buffer_keys)
     end
 
     def run
@@ -676,7 +650,7 @@ class LustyJuggler
       end
 
       # Cancel keys.
-      @CANCEL_MAPPINGS.each do |c|
+      cancel_mappings.each do |c|
         map_key(c, ":call <SID>LustyJugglerCancel()<CR>")
       end
 
@@ -721,7 +695,7 @@ class LustyJuggler
       @KEYPRESS_MAPPINGS.keys.each do |c|
         unmap_key(c)
       end
-      @CANCEL_MAPPINGS.each do |c|
+      cancel_mappings.each do |c|
         unmap_key(c)
       end
 
@@ -803,63 +777,88 @@ class LustyJuggler
         end
       end
     end
-end
 
-class LustyJugglerDvorak < LustyJuggler
-  public
-    def initialize
-      super
-      alpha_buffer_keys = [
-        "a",
-        "o",
-        "e",
-        "u",
+    def default_cancel_mappings
+      [
         "i",
-        "d",
-        "h",
-        "t",
-        "n",
-        "s",
-      ]
-      @name_bar = NameBar.new(alpha_buffer_keys)
-      @ALPHA_BUFFER_KEYS = Hash.new
-      alpha_buffer_keys.each_with_index {|x, i| @ALPHA_BUFFER_KEYS[x] = i + 1}
-      @BUFFER_KEYS = @ALPHA_BUFFER_KEYS.merge(@NUMERIC_BUFFER_KEYS)
-      @KEYPRESS_MAPPINGS = @BUFFER_KEYS.merge(@KEYPRESS_KEYS)
-      ["i", "o"].each do |old_cancel_key| @CANCEL_MAPPINGS.delete(old_cancel_key) end
-    end
-end
-
-class LustyJugglerColemak < LustyJuggler
-  public
-    def initialize
-      super
-      alpha_buffer_keys = [
-        "a",
+        "I",
+        "A",
+        "c",
+        "C",
+        "o",
+        "O",
+        "S",
         "r",
-        "s",
-        "t",
-        "d",
-        "h",
-        "n",
-        "e",
-        "i",
-        "o",
+        "R",
+        "q",
+        "<Esc>",
+        "<C-c>",
+        "<BS>",
+        "<Del>",
+        "<C-h>"
       ]
-      @name_bar = NameBar.new(alpha_buffer_keys)
-      @ALPHA_BUFFER_KEYS = Hash.new
-      alpha_buffer_keys.each_with_index {|x, i| @ALPHA_BUFFER_KEYS[x] = i + 1}
-      @BUFFER_KEYS = @ALPHA_BUFFER_KEYS.merge(@NUMERIC_BUFFER_KEYS)
-      @KEYPRESS_MAPPINGS = @BUFFER_KEYS.merge(@KEYPRESS_KEYS)
-      ["r", "i", "o"].each do |old_cancel_key| @CANCEL_MAPPINGS.delete(old_cancel_key) end
     end
-end
+  end
 
-class LustyJugglerBepo < LustyJuggler
-  public
-    def initialize
-      super
-      alpha_buffer_keys = [
+  class LustyJuggler < BaseLustyJuggler
+    private
+    def alpha_buffer_keys
+      [
+        "a",
+        "s",
+        "d",
+        "f",
+        "g",
+        "h",
+        "j",
+        "k",
+        "l",
+        ";",
+      ]
+    end
+
+  end
+
+  class LustyJugglerDvorak < LustyJuggler
+    private
+      def alpha_buffer_keys
+        [
+          "a",
+          "o",
+          "e",
+          "u",
+          "i",
+          "d",
+          "h",
+          "t",
+          "n",
+          "s"
+        ]
+      end
+  end
+
+  class LustyJugglerColemak < LustyJuggler
+    private
+      def alpha_buffer_keys
+        [
+          "a",
+          "r",
+          "s",
+          "t",
+          "d",
+          "h",
+          "n",
+          "e",
+          "i",
+          "o",
+        ]
+      end
+  end
+
+  class LustyJugglerBepo < LustyJuggler
+    private
+    def alpha_buffer_keys
+      [
         "a",
         "u",
         "i",
@@ -871,21 +870,13 @@ class LustyJugglerBepo < LustyJuggler
         "n",
         "m",
       ]
-      @name_bar = NameBar.new(alpha_buffer_keys)
-      @ALPHA_BUFFER_KEYS = Hash.new
-      alpha_buffer_keys.each_with_index {|x, i| @ALPHA_BUFFER_KEYS[x] = i + 1}
-      @BUFFER_KEYS = @ALPHA_BUFFER_KEYS.merge(@NUMERIC_BUFFER_KEYS)
-      @KEYPRESS_MAPPINGS = @BUFFER_KEYS.merge(@KEYPRESS_KEYS)
-      @CANCEL_MAPPINGS.delete("i")
-      @CANCEL_MAPPINGS.push("c")
     end
-end
+  end
 
-class LustyJugglerAzerty < LustyJuggler
-  public
-    def initialize
-      super
-      alpha_buffer_keys = [
+  class LustyJugglerAzerty < LustyJuggler
+    private
+    def alpha_buffer_keys
+      [
         "q",
         "s",
         "d",
@@ -897,16 +888,8 @@ class LustyJugglerAzerty < LustyJuggler
         "m",
         "ù",
       ]
-      @name_bar = NameBar.new(alpha_buffer_keys)
-      @ALPHA_BUFFER_KEYS = Hash.new
-      alpha_buffer_keys.each_with_index {|x, i| @ALPHA_BUFFER_KEYS[x] = i + 1}
-      @BUFFER_KEYS = @ALPHA_BUFFER_KEYS.merge(@NUMERIC_BUFFER_KEYS)
-      @KEYPRESS_MAPPINGS = @BUFFER_KEYS.merge(@KEYPRESS_KEYS)
-      @CANCEL_MAPPINGS.delete("q")
-      @CANCEL_MAPPINGS.push("c")
-      @CANCEL_MAPPINGS.push("a")
     end
-end
+    end
 end
 
 # An item (delimiter/separator or buffer name) on the NameBar.

--- a/src/lusty/juggler.rb
+++ b/src/lusty/juggler.rb
@@ -8,23 +8,11 @@
 # software.
 
 module LustyM
-class LustyJuggler
+class BaseLustyJuggler
   public
     def initialize
       @running = false
       @last_pressed = nil
-      alpha_buffer_keys = [
-        "a",
-        "s",
-        "d",
-        "f",
-        "g",
-        "h",
-        "j",
-        "k",
-        "l",
-        ";",
-      ]
       @name_bar = NameBar.new(alpha_buffer_keys)
       @ALPHA_BUFFER_KEYS = Hash.new
       alpha_buffer_keys.each_with_index {|x, i| @ALPHA_BUFFER_KEYS[x] = i + 1}
@@ -58,24 +46,10 @@ class LustyJuggler
         "<Right>" => "Right",
       }
       @KEYPRESS_MAPPINGS = @BUFFER_KEYS.merge(@KEYPRESS_KEYS)
-      @CANCEL_MAPPINGS = [
-        "i",
-        "I",
-        "A",
-        "c",
-        "C",
-        "o",
-        "O",
-        "S",
-        "r",
-        "R",
-        "q",
-        "<Esc>",
-        "<C-c>",
-        "<BS>",
-        "<Del>",
-        "<C-h>",
-      ]
+    end
+
+    def cancel_mappings
+      @cancel_mappings ||= (default_cancel_mappings - alpha_buffer_keys)
     end
 
     def run
@@ -112,7 +86,7 @@ class LustyJuggler
       end
 
       # Cancel keys.
-      @CANCEL_MAPPINGS.each do |c|
+      cancel_mappings.each do |c|
         map_key(c, ":call <SID>LustyJugglerCancel()<CR>")
       end
 
@@ -157,7 +131,7 @@ class LustyJuggler
       @KEYPRESS_MAPPINGS.keys.each do |c|
         unmap_key(c)
       end
-      @CANCEL_MAPPINGS.each do |c|
+      cancel_mappings.each do |c|
         unmap_key(c)
       end
 
@@ -239,63 +213,88 @@ class LustyJuggler
         end
       end
     end
-end
 
-class LustyJugglerDvorak < LustyJuggler
-  public
-    def initialize
-      super
-      alpha_buffer_keys = [
-        "a",
-        "o",
-        "e",
-        "u",
+    def default_cancel_mappings
+      [
         "i",
-        "d",
-        "h",
-        "t",
-        "n",
-        "s",
-      ]
-      @name_bar = NameBar.new(alpha_buffer_keys)
-      @ALPHA_BUFFER_KEYS = Hash.new
-      alpha_buffer_keys.each_with_index {|x, i| @ALPHA_BUFFER_KEYS[x] = i + 1}
-      @BUFFER_KEYS = @ALPHA_BUFFER_KEYS.merge(@NUMERIC_BUFFER_KEYS)
-      @KEYPRESS_MAPPINGS = @BUFFER_KEYS.merge(@KEYPRESS_KEYS)
-      ["i", "o"].each do |old_cancel_key| @CANCEL_MAPPINGS.delete(old_cancel_key) end
-    end
-end
-
-class LustyJugglerColemak < LustyJuggler
-  public
-    def initialize
-      super
-      alpha_buffer_keys = [
-        "a",
+        "I",
+        "A",
+        "c",
+        "C",
+        "o",
+        "O",
+        "S",
         "r",
-        "s",
-        "t",
-        "d",
-        "h",
-        "n",
-        "e",
-        "i",
-        "o",
+        "R",
+        "q",
+        "<Esc>",
+        "<C-c>",
+        "<BS>",
+        "<Del>",
+        "<C-h>"
       ]
-      @name_bar = NameBar.new(alpha_buffer_keys)
-      @ALPHA_BUFFER_KEYS = Hash.new
-      alpha_buffer_keys.each_with_index {|x, i| @ALPHA_BUFFER_KEYS[x] = i + 1}
-      @BUFFER_KEYS = @ALPHA_BUFFER_KEYS.merge(@NUMERIC_BUFFER_KEYS)
-      @KEYPRESS_MAPPINGS = @BUFFER_KEYS.merge(@KEYPRESS_KEYS)
-      ["r", "i", "o"].each do |old_cancel_key| @CANCEL_MAPPINGS.delete(old_cancel_key) end
     end
-end
+  end
 
-class LustyJugglerBepo < LustyJuggler
-  public
-    def initialize
-      super
-      alpha_buffer_keys = [
+  class LustyJuggler < BaseLustyJuggler
+    private
+    def alpha_buffer_keys
+      [
+        "a",
+        "s",
+        "d",
+        "f",
+        "g",
+        "h",
+        "j",
+        "k",
+        "l",
+        ";",
+      ]
+    end
+
+  end
+
+  class LustyJugglerDvorak < LustyJuggler
+    private
+      def alpha_buffer_keys
+        [
+          "a",
+          "o",
+          "e",
+          "u",
+          "i",
+          "d",
+          "h",
+          "t",
+          "n",
+          "s"
+        ]
+      end
+  end
+
+  class LustyJugglerColemak < LustyJuggler
+    private
+      def alpha_buffer_keys
+        [
+          "a",
+          "r",
+          "s",
+          "t",
+          "d",
+          "h",
+          "n",
+          "e",
+          "i",
+          "o",
+        ]
+      end
+  end
+
+  class LustyJugglerBepo < LustyJuggler
+    private
+    def alpha_buffer_keys
+      [
         "a",
         "u",
         "i",
@@ -307,21 +306,13 @@ class LustyJugglerBepo < LustyJuggler
         "n",
         "m",
       ]
-      @name_bar = NameBar.new(alpha_buffer_keys)
-      @ALPHA_BUFFER_KEYS = Hash.new
-      alpha_buffer_keys.each_with_index {|x, i| @ALPHA_BUFFER_KEYS[x] = i + 1}
-      @BUFFER_KEYS = @ALPHA_BUFFER_KEYS.merge(@NUMERIC_BUFFER_KEYS)
-      @KEYPRESS_MAPPINGS = @BUFFER_KEYS.merge(@KEYPRESS_KEYS)
-      @CANCEL_MAPPINGS.delete("i")
-      @CANCEL_MAPPINGS.push("c")
     end
-end
+  end
 
-class LustyJugglerAzerty < LustyJuggler
-  public
-    def initialize
-      super
-      alpha_buffer_keys = [
+  class LustyJugglerAzerty < LustyJuggler
+    private
+    def alpha_buffer_keys
+      [
         "q",
         "s",
         "d",
@@ -333,14 +324,6 @@ class LustyJugglerAzerty < LustyJuggler
         "m",
         "ù",
       ]
-      @name_bar = NameBar.new(alpha_buffer_keys)
-      @ALPHA_BUFFER_KEYS = Hash.new
-      alpha_buffer_keys.each_with_index {|x, i| @ALPHA_BUFFER_KEYS[x] = i + 1}
-      @BUFFER_KEYS = @ALPHA_BUFFER_KEYS.merge(@NUMERIC_BUFFER_KEYS)
-      @KEYPRESS_MAPPINGS = @BUFFER_KEYS.merge(@KEYPRESS_KEYS)
-      @CANCEL_MAPPINGS.delete("q")
-      @CANCEL_MAPPINGS.push("c")
-      @CANCEL_MAPPINGS.push("a")
     end
-end
+    end
 end


### PR DESCRIPTION
Hi,

sometimes, keymappings are not reset properly (when pressing the wrong keys when LJ is open).

The first commit adds some extra cancel keys.

The second commit extracts methods for the default_cancel_keys and alpha_buffer_keys for all keyboard mappings. It then subtracts them when necessary. This way, the cancel key mappings should always be correct.

I could not get the test suite to work, though: I don't know what to do with the 'expect' command.
