### PR TITLE
lusty-juggler: preserve the "<script>" tag when restoring a mapping

### DIFF
--- a/autoload/lustyjuggler.vim
+++ b/autoload/lustyjuggler.vim
@@ -471,6 +471,12 @@ class BaseLustyJuggler
       VIM::command "sb #{buf}"
     end
 
+    def needs_script?(mode, key)
+        VIM::command "redir => s:needs_script | #{mode}map #{key} | redir END"
+        mapping = VIM::evaluate("s:needs_script").split
+        return ((mapping.length > 2) and (mapping[2] == '&'))
+    end
+
     def map_key(key, action)
       ['n','s','x','o','i','c','l'].each do |mode|
         VIM::command "let s:maparg_holder = maparg('#{key}', '#{mode}')"
@@ -482,7 +488,8 @@ class BaseLustyJuggler
             silent  = VIM::evaluate_bool("s:maparg_dict_holder['silent']")  ? ' <silent>' : ''
             expr    = VIM::evaluate_bool("s:maparg_dict_holder['expr']")    ? ' <expr>'   : ''
             buffer  = VIM::evaluate_bool("s:maparg_dict_holder['buffer']")  ? ' <buffer>' : ''
-            restore_cmd = "#{mode}#{nore}map#{silent}#{expr}#{buffer} #{key} #{orig_rhs}"
+            script  = needs_script?(mode, key) ? ' <script>' : ''
+            restore_cmd = "#{mode}#{nore}map#{silent}#{expr}#{buffer}#{script} #{key} #{orig_rhs}"
           else
             nore = LustyJ::starts_with?(orig_rhs, '<Plug>') ? '' : 'nore'
             restore_cmd = "#{mode}#{nore}map <silent> #{key} #{orig_rhs}"

--- a/src/lusty/juggler.rb
+++ b/src/lusty/juggler.rb
@@ -176,6 +176,12 @@ class BaseLustyJuggler
       VIM::command "sb #{buf}"
     end
 
+    def needs_script?(mode, key)
+        VIM::command "redir => s:needs_script | #{mode}map #{key} | redir END"
+        mapping = VIM::evaluate("s:needs_script").split
+        return ((mapping.length > 2) and (mapping[2] == '&'))
+    end
+
     def map_key(key, action)
       ['n','s','x','o','i','c','l'].each do |mode|
         VIM::command "let s:maparg_holder = maparg('#{key}', '#{mode}')"
@@ -187,7 +193,8 @@ class BaseLustyJuggler
             silent  = VIM::evaluate_bool("s:maparg_dict_holder['silent']")  ? ' <silent>' : ''
             expr    = VIM::evaluate_bool("s:maparg_dict_holder['expr']")    ? ' <expr>'   : ''
             buffer  = VIM::evaluate_bool("s:maparg_dict_holder['buffer']")  ? ' <buffer>' : ''
-            restore_cmd = "#{mode}#{nore}map#{silent}#{expr}#{buffer} #{key} #{orig_rhs}"
+            script  = needs_script?(mode, key) ? ' <script>' : ''
+            restore_cmd = "#{mode}#{nore}map#{silent}#{expr}#{buffer}#{script} #{key} #{orig_rhs}"
           else
             nore = LustyM::starts_with?(orig_rhs, '<Plug>') ? '' : 'nore'
             restore_cmd = "#{mode}#{nore}map <silent> #{key} #{orig_rhs}"


### PR DESCRIPTION
This is a true fix for #20.  The `maparg()` function still does not
report back enough information to know whether or not the "<script>" tag
was specified for the mapping.  So, let's take another approach and
parse the output of the map command.  The presence of an "&" appears to
be a good indicator that you need the "<script>" tag.  Let's key off
that and use that information when generating the command to restore the
mapping.
