### PR TITLE
Ruby 2.4 deprecates Fixnum, match Integer first.

### DIFF
--- a/autoload/lustyexplorer.vim
+++ b/autoload/lustyexplorer.vim
@@ -75,6 +75,8 @@ module VIM
     case var
     when String
       var == "0"
+    when Integer
+      var == 0
     when Fixnum
       var == 0
     else

--- a/autoload/lustyjuggler.vim
+++ b/autoload/lustyjuggler.vim
@@ -51,6 +51,8 @@ module VIM
     case var
     when String
       var == "0"
+    when Integer
+      var == 0
     when Fixnum
       var == 0
     else

--- a/src/vim.rb
+++ b/src/vim.rb
@@ -19,6 +19,8 @@ module VIM
     case var
     when String
       var == "0"
+    when Integer
+      var == 0
     when Fixnum
       var == 0
     else


### PR DESCRIPTION
This avoids the warning.